### PR TITLE
BAT-042: split marketplace unit and e2e test runners

### DIFF
--- a/apps/marketplace-app/package.json
+++ b/apps/marketplace-app/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint . --ext ts,tsx",
     "test:e2e": "bash ../../scripts/run-marketplace-e2e.sh",
     "test:e2e:ui": "playwright test --ui",
-    "test": "vitest",
+    "test": "vitest --config vitest.config.ts",
     "cap:sync": "pnpm build && npx cap sync",
     "cap:open:ios": "npx cap open ios",
     "cap:open:android": "npx cap open android",

--- a/apps/marketplace-app/vitest.config.ts
+++ b/apps/marketplace-app/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    include: [
+      'src/**/*.{test,spec}.ts',
+      'src/**/*.{test,spec}.tsx',
+      'tests/unit/**/*.{test,spec}.ts',
+      'tests/unit/**/*.{test,spec}.tsx',
+    ],
+    exclude: [
+      'tests/e2e/**',
+      'tests/vendor-pages.spec.ts',
+      'playwright*.config.ts',
+    ],
+  },
+})


### PR DESCRIPTION
## Summary
- switch marketplace unit test script to use explicit Vitest config
- add vitest.config.ts to include only unit test globs and exclude Playwright e2e specs
- remove package-level inline Vitest config to prevent Playwright suite discovery during unit runs

## Validation
- pnpm --filter @gosenderr/marketplace-app test -- --run
- pnpm --filter @gosenderr/marketplace-app build
- bash /Users/papadev/dev/worktrees/gosenderr/full-audit.sh from workspace root (smoke marketplace tests now pass; remaining failures are unrelated local steps)

## BAT
- BAT-042
